### PR TITLE
Fix negative hash values and add destringify function

### DIFF
--- a/bloem.js
+++ b/bloem.js
@@ -22,7 +22,7 @@ function calulateHashes(key, size, slices) {
 		var h = new FNV()
 		h.update(seed)
 		h.update(data)
-		return h.value()
+		return h.value() >>> 0
 	}
 	var h1 = fnv(Buffer("S"), key)
 	var h2 = fnv(Buffer("W"), key)
@@ -62,6 +62,14 @@ function SafeBloem(capacity, error_rate) {
 	this.error_rate = error_rate
 	this.count  = 0
 	this.filter = new Bloem(size, slices)
+}
+
+SafeBloem.destringify = function(data) {
+	var bloem = new SafeBloem(data.capacity, data.error_rate)
+	bloem.count  = data.count
+	bloem.filter.bitfield.buffer = new Buffer(data.filter.bitfield.buffer)
+
+	return bloem
 }
 
 SafeBloem.prototype = {


### PR DESCRIPTION
Added destringify function that accepts a json object. It was also necessary to ensure that calulateHashes returns only positive values.

```
var bf0, bfJson, bloem, fs, json, word, words, _i, _j, _len, _len1;
bloem = require('bloem');
fs = require('fs');

bf0 = new bloem.SafeBloem(5, 0.01);

words = ["monkey", "tree", "beef", "goat", "hamburger"];

for (_i = 0, _len = words.length; _i < _len; _i++) {
  word = words[_i];
  bf0.add(word);
}

fs.writeFileSync("./test.json", JSON.stringify(bf0, null, "  "));

json = require('./test');

bfJson = bloem.SafeBloem.destringify(json);

for (_j = 0, _len1 = words.length; _j < _len1; _j++) {
  word = words[_j];
  console.log(word, bfJson.has(word), bf0.has(word));
  console.log(word + "foo", bfJson.has(word + "foo"), bf0.has(word + "foo"));
}

console.log(bfJson.filter.bitfield);

console.log(bf0.filter.bitfield);
```

monkey true true
monkeyfoo false false
tree true true
treefoo false false
beef true true
beeffoo false false
goat true true
goatfoo false false
hamburger true true
hamburgerfoo false false
{ buffer: <Buffer e9 4b a5 3f d4 17> }
{ buffer: <Buffer e9 4b a5 3f d4 17> }
