### PR TITLE
Add binary serialization to the Bloem filter

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -10,7 +10,9 @@ suite
     .add('json serialization', function() {
         bloem.Bloem.destringify(JSON.parse(JSON.stringify(serializeTest)))
     }).add('binary serialization', function() {
-        bloem.Bloem.deserialize(serializeTest.serialize())
+        serializeTest.serialize(function (err, data) {
+            bloem.Bloem.deserialize({ data: data }, function () {});
+        });
     }).on('cycle', function(event) {
         console.log(String(event.target))
     }).run()

--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,16 @@
+var Benchmark = require('benchmark')
+var bloem = require('./bloem')
+var suite = new Benchmark.Suite
+
+
+var serializeTest = new bloem.Bloem(8, 2)
+serializeTest.add(Buffer("foo"))
+
+suite
+    .add('json serialization', function() {
+        bloem.Bloem.destringify(JSON.parse(JSON.stringify(serializeTest)))
+    }).add('binary serialization', function() {
+        bloem.Bloem.deserialize(serializeTest.serialize())
+    }).on('cycle', function(event) {
+        console.log(String(event.target))
+    }).run()

--- a/bloem.js
+++ b/bloem.js
@@ -52,6 +52,13 @@ Bloem.prototype = {
 			if(!this.bitfield.get(hashes[i])) return false
 		}
 		return true
+	},
+	serialize: function() {
+		var meta = new Buffer(8)
+		meta.writeUInt32BE(this.size, 0)
+		meta.writeUInt32BE(this.slices, 4)
+
+		return Buffer.concat([meta, this.bitfield.buffer])
 	}
 }
 
@@ -59,6 +66,14 @@ Bloem.destringify = function(data) {
 	var filter = new Bloem(data.size, data.slices)
 	filter.bitfield.buffer = new Buffer(data.bitfield.buffer)
 	return filter
+}
+
+Bloem.deserialize = function(buffer) {
+	return new Bloem(
+		buffer.readUInt32BE(0),
+		buffer.readUInt32BE(4),
+		buffer.slice(8)
+	)
 }
 
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
 		"bitbuffer": "0.1.x"
 	},
 	"devDependencies": {
-		"mocha": "1.8.x"
+		"mocha": "1.8.x",
+		"benchmark": "^1.0.0"
 	},
 	"scripts": {
 		"test": "mocha -u qunit -R list"

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ All use the FNV Hash function and the optimization described in [[1](#lesshash)]
 	filter.add(Buffer("1")) // true
 	filter.add(Buffer("2")) // true
 	filter.add(Buffer("3")) // false
-	
+
 	filter.has(Buffer("3")) // false
 	filter.has(Buffer("1")) // true
 
@@ -57,6 +57,23 @@ Add a key to the set
 
 Test if key is in the set
 
+
+##### filter.serialize([options,] callback)
+
+- <code>options</code> Object - can contain the following properties:
+	- <code>gzip</code> Boolean - if set to true, the filter will be compressed
+- <code>callback</code> Function - called with the resulting (Error, Buffer)
+
+Serializes the bloop filter into a buffer.
+
+##### Bloem.deserialize(options, callback)
+
+- <code>options</code> Object - can contain the following properties:
+	- <code>data</code> Buffer - as received from the serialize method
+	- <code>gzip</code> Boolean - if set to true, the filter will be deflated
+- <code>callback</code> Function - called with the resulting (Error, Bloem)
+
+Deserializes a previously serialized Bloem filter.
 
 ### Class: SafeBloem
 

--- a/test.js
+++ b/test.js
@@ -25,14 +25,38 @@ test('#destringify', function() {
 	assert.equal(f.has(Buffer("bar")), false)
 })
 
-test('#serialize', function() {
+test('#serialize', function(done) {
 	var start = new bloem.Bloem(8, 2)
 	start.add(Buffer("foo"))
-	var end = bloem.Bloem.deserialize(start.serialize())
+	start.serialize(function (err, data) {
+		if (err) return done(err)
 
-	assert(end.bitfield.toBuffer().equals(start.bitfield.toBuffer()));
-	assert.equal(end.size, start.size);
-	assert.equal(end.slices, start.slices);
+		bloem.Bloem.deserialize({ data: data }, function (err, end) {
+			if (err) return done(err)
+
+			assert(end.bitfield.toBuffer().equals(start.bitfield.toBuffer()))
+			assert.equal(end.size, start.size)
+			assert.equal(end.slices, start.slices)
+			done()
+		});
+	});
+});
+
+test('#serialize-gzip', function(done) {
+	var start = new bloem.Bloem(8, 2)
+	start.add(Buffer("foo"))
+	start.serialize({ gzip: true }, function (err, data) {
+		if (err) return done(err)
+
+		bloem.Bloem.deserialize({ data: data, gzip: true }, function (err, end) {
+			if (err) return done(err)
+
+			assert(end.bitfield.toBuffer().equals(start.bitfield.toBuffer()));
+			assert.equal(end.size, start.size);
+			assert.equal(end.slices, start.slices);
+			done()
+		});
+	});
 });
 
 

--- a/test.js
+++ b/test.js
@@ -25,6 +25,16 @@ test('#destringify', function() {
 	assert.equal(f.has(Buffer("bar")), false)
 })
 
+test('#serialize', function() {
+	var start = new bloem.Bloem(8, 2)
+	start.add(Buffer("foo"))
+	var end = bloem.Bloem.deserialize(start.serialize())
+
+	assert(end.bitfield.toBuffer().equals(start.bitfield.toBuffer()));
+	assert.equal(end.size, start.size);
+	assert.equal(end.slices, start.slices);
+});
+
 
 suite('SafeBloem')
 


### PR DESCRIPTION
I added basic binary serialization to the Bloem filter as discussed in #5. It does appear to be significantly faster than the previously recommended way of JSON stringification.

```
$ node bench.js
json serialization x 127,989 ops/sec ±1.78% (90 runs sampled)
binary serialization x 654,750 ops/sec ±1.65% (91 runs sampled)
```
